### PR TITLE
Moving PackageReferences back to project file

### DIFF
--- a/test/ResumeService.WebApi.HttpIntegration/Directory.Build.props
+++ b/test/ResumeService.WebApi.HttpIntegration/Directory.Build.props
@@ -7,18 +7,6 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.analyzers" Version="1.6.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup Label="Implicit usings">
     <Using Include="FluentAssertions" />
     <Using Include="NSubstitute" />

--- a/test/ResumeService.WebApi.HttpIntegration/Directory.Build.props
+++ b/test/ResumeService.WebApi.HttpIntegration/Directory.Build.props
@@ -7,7 +7,13 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
-  <ItemGroup Label="Implicit usings">
+  <ItemGroup Label="Global using not covered by implicit using">
+    <Using Include="System.Net.Http.Json" />
+    <Using Include="Microsoft.AspNetCore.Hosting" />
+    <Using Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="Microsoft.Extensions.DependencyInjection.Extensions" />
+    <Using Include="Microsoft.Extensions.Hosting" />
     <Using Include="FluentAssertions" />
     <Using Include="NSubstitute" />
     <Using Include="Xunit" />

--- a/test/ResumeService.WebApi.HttpIntegration/ResumeService.WebApi.HttpIntegration.csproj
+++ b/test/ResumeService.WebApi.HttpIntegration/ResumeService.WebApi.HttpIntegration.csproj
@@ -1,6 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.analyzers" Version="1.6.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit.Injectable" Version="2.1.6" />

--- a/test/ResumeService.WebApi.HttpIntegration/ResumeService.WebApi.HttpIntegration.csproj
+++ b/test/ResumeService.WebApi.HttpIntegration/ResumeService.WebApi.HttpIntegration.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />


### PR DESCRIPTION
It builds, but having PackageReferences in the `Directory.Build.props` file just breaks tooling in some many ways (e.g. Visual Studio and dotnet CLI) when working with packages