### PR TITLE
Ignoring CA2007 in projects where it is not relevant 

### DIFF
--- a/src/ResumeService/ResumeService.csproj
+++ b/src/ResumeService/ResumeService.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <!-- Ignoring CA2007 "Consider adding .ConfigureAwait(false)" as web root project is never a library -->
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <!-- Ignoring CA2007 "Consider adding .ConfigureAwait(false)" as no test projects are libraries -->
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/test/ResumeService.WebApi.HttpIntegration/Directory.Build.props
+++ b/test/ResumeService.WebApi.HttpIntegration/Directory.Build.props
@@ -2,11 +2,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-  </PropertyGroup>
-
   <ItemGroup Label="Global using not covered by implicit using">
     <Using Include="System.Net.Http.Json" />
     <Using Include="Microsoft.AspNetCore.Hosting" />


### PR DESCRIPTION
- Adding extra Directory.Build.props in test folder and moving a few properties from HttpIntegrationTest project
- Ignoring CA2007 in web root project